### PR TITLE
Build docs using conda on RTD

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,15 @@
+name: pdspect-docs
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+- python=3
+- ginga==2.6.0
+- planetaryimage>=0.5.0
+- matplotlib>=1.5.1
+- qtpy>=1.2.1
+- sphinx>=1.4
+- sphinx_rtd_theme
+- pip:
+  - planetary-test-data==0.3.3
+  - git+https://github.com/willingc/pdsspect

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,4 +1,4 @@
-name: pdspect-docs
+name: pdsspect-docs
 channels:
   - conda-forge
   - defaults
@@ -12,4 +12,4 @@ dependencies:
 - sphinx_rtd_theme
 - pip:
   - planetary-test-data==0.3.3
-  - git+https://github.com/willingc/pdsspect
+  - git+https://github.com/planetarypy/pdsspect

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,6 @@
+name: pdsspect
+type: sphinx
+conda:
+    file: docs/environment.yml
+python:
+   version: 3


### PR DESCRIPTION
This PR adds support for building docs on RTD using conda instead of pip. I tried with no success to get it to build using pip but the gcc error persisted through a number of config changes.

[Rendered docs on my test account using this PR's config](http://test-pdsspect.readthedocs.io/en/new-build/)

Closes https://github.com/rtfd/readthedocs.org/issues/3010